### PR TITLE
Allow "Set Checkpoint" on an empty command stack

### DIFF
--- a/OpenSudoku/src/cz/romario/opensudoku/game/command/CommandStack.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/command/CommandStack.java
@@ -56,10 +56,11 @@ public class CommandStack {
 	}
 
 	public void setCheckpoint() {
-		if (!mCommandStack.empty()) {
-			AbstractCommand c = mCommandStack.peek();
-			c.setCheckpoint(true);
+		if (mCommandStack.empty()) {
+			mCommandStack.push(new NoOpCommand());
 		}
+		AbstractCommand c = mCommandStack.peek();
+		c.setCheckpoint(true);
 	}
 
 	public boolean hasCheckpoint() {

--- a/OpenSudoku/src/cz/romario/opensudoku/game/command/NoOpCommand.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/command/NoOpCommand.java
@@ -1,0 +1,19 @@
+package cz.romario.opensudoku.game.command;
+
+public class NoOpCommand extends AbstractCommand {
+
+	public NoOpCommand(){
+		// nothing to initialize 
+	}
+	
+	@Override
+	void execute() {
+		// do nothing
+	}
+
+	@Override
+	void undo() {
+		// nothing to undo
+	}
+
+}


### PR DESCRIPTION
I have added a NoOpCommand subclass of AbstractCommand. If a user attempts to set a checkpoint on an empty command stack (for example, when coming back to a partially completed puzzle after rebooting the device) a NoOpCommand is pushed to the command stack before setCheckpoint(true) is called. The NoOpCommand has no other behaviors.
