### PR TITLE
Night theme / simple auto-solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 OpenSudoku/bin/
 OpenSudoku/gen/
+misc
+.gradle
+.idea
+build
+local.properties
+gradle
+gradlew
+gradlew.bat
+*.iml

--- a/OpenSudoku/.classpath
+++ b/OpenSudoku/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/OpenSudoku/AndroidManifest.xml
+++ b/OpenSudoku/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 		  package="cz.romario.opensudoku"
-		  android:installLocation="auto" android:versionName="1.1.5" android:versionCode="1105">
+		  android:installLocation="auto" android:versionName="1.1.6" android:versionCode="1105">
 	<uses-sdk android:minSdkVersion="3" android:targetSdkVersion="4"/>
 	<application android:icon="@drawable/opensudoku_logo_72" android:label="@string/app_name">
 		<activity android:name=".gui.FolderListActivity"
@@ -70,4 +70,4 @@
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
-</manifest> 
+</manifest>

--- a/OpenSudoku/build.gradle
+++ b/OpenSudoku/build.gradle
@@ -1,0 +1,42 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.5.+'
+    }
+}
+apply plugin: 'android'
+
+dependencies {
+    compile fileTree(dir: 'libs', include: '*.jar')
+}
+
+android {
+    compileSdkVersion 10
+    buildToolsVersion "18.1.0"
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        // Move the tests to tests/java, tests/res, etc...
+        instrumentTest.setRoot('tests')
+
+        // Move the build types to build-types/<type>
+        // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
+        // This moves them out of them default location under src/<type>/... which would
+        // conflict with src/ being used by the main source set.
+        // Adding new build types or product flavors should be accompanied
+        // by a similar customization.
+        debug.setRoot('build-types/debug')
+        release.setRoot('build-types/release')
+    }
+}

--- a/OpenSudoku/res/values/arrays.xml
+++ b/OpenSudoku/res/values/arrays.xml
@@ -9,12 +9,14 @@
 		<item>Default</item>
 		<item>Paper I</item>
 		<item>Paper II</item>
+        <item>Night</item>
 	</string-array>
 	<!-- Theme codes should not change, do not translate this! -->
 	<string-array name="theme_codes">
 		<item>default</item>
 		<item>paperi</item>
 		<item>paperii</item>
+        <item>night</item>
 	</string-array>
 	<string-array name="game_levels">
 		<item>Easy</item>

--- a/OpenSudoku/res/values/strings.xml
+++ b/OpenSudoku/res/values/strings.xml
@@ -208,6 +208,8 @@
 
     <!-- Strings added/changed in 1.1.6 (ralfoide fork) -->
     <string name="fill_in_notes_auto">Auto fill in notes</string>
-    <string name="fill_in_notes_auto_summary">Auto fill notes where possible.</string>
+    <string name="fill_in_notes_auto_summary">Automatically fill in notes after each move.</string>
+    <string name="auto_play">Auto-play trivial moves.</string>
+    <string name="auto_play_summary">Automatically perform trivial moves (w/ 1 second delay).</string>
 
 </resources>

--- a/OpenSudoku/res/values/strings.xml
+++ b/OpenSudoku/res/values/strings.xml
@@ -205,4 +205,9 @@
 	<string name="set_checkpoint">Set checkpoint</string>
 	<string name="undo_to_checkpoint">Undo to checkpoint</string>
 	<string name="undo_to_checkpoint_confirm">Are you sure you want to undo all actions since last checkpoint?</string>
+
+    <!-- Strings added/changed in 1.1.6 (ralfoide fork) -->
+    <string name="fill_in_notes_auto">Auto fill in notes</string>
+    <string name="fill_in_notes_auto_summary">Auto fill notes where possible.</string>
+
 </resources>

--- a/OpenSudoku/res/values/styles.xml
+++ b/OpenSudoku/res/values/styles.xml
@@ -63,4 +63,16 @@
 		<item name="backgroundColorTouched">#3232ff</item>
 		<item name="backgroundColorSelected">#ffff00</item>
 	</style>
+    <!-- A green-on-black dark theme called "Night" in the Theme settings. -->
+    <style name="Theme.Night">
+        <item name="lineColor">#F666</item>
+        <item name="sectorLineColor">#F0F0</item>
+        <item name="textColor">#F0F0</item>
+        <item name="textColorReadOnly">#F3C0</item>
+        <item name="textColorNote">#F0F0</item>
+        <item name="backgroundColor">@android:color/black</item>
+        <item name="backgroundColorReadOnly">#F060</item>
+        <item name="backgroundColorTouched">#3232ff</item>
+        <item name="backgroundColorSelected">#FFFF</item>
+    </style>
 </resources>

--- a/OpenSudoku/res/xml/game_settings.xml
+++ b/OpenSudoku/res/xml/game_settings.xml
@@ -24,6 +24,12 @@
 				android:title="@string/fill_in_notes"
 				android:summary="@string/fill_in_notes_summary"
 				android:defaultValue="false"/>
+        <CheckBoxPreference
+                android:defaultValue="false"
+                android:title="@string/fill_in_notes_auto"
+                android:key="fill_in_notes_auto"
+                android:summary="@string/fill_in_notes_auto_summary"
+                android:dependency="fill_in_notes_enabled"/>
 	</PreferenceCategory>
 	<PreferenceCategory
 			android:title="@string/input_methods">

--- a/OpenSudoku/res/xml/game_settings.xml
+++ b/OpenSudoku/res/xml/game_settings.xml
@@ -30,6 +30,12 @@
                 android:key="fill_in_notes_auto"
                 android:summary="@string/fill_in_notes_auto_summary"
                 android:dependency="fill_in_notes_enabled"/>
+        <CheckBoxPreference
+                android:defaultValue="false"
+                android:title="@string/auto_play"
+                android:key="auto_play"
+                android:summary="@string/auto_play_summary"
+                android:dependency="fill_in_notes_auto"/>
 	</PreferenceCategory>
 	<PreferenceCategory
 			android:title="@string/input_methods">

--- a/OpenSudoku/src/cz/romario/opensudoku/game/AutoPlaySolver.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/AutoPlaySolver.java
@@ -40,8 +40,8 @@ public class AutoPlaySolver {
         return mValue;
     }
 
+    /** Returns true if one cell candidate was found. */
     public boolean solveNext(CellCollection cells) {
-
         Cell candidateCell = null;
         int newValue = 0;
 

--- a/OpenSudoku/src/cz/romario/opensudoku/game/AutoPlaySolver.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/AutoPlaySolver.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2009 Ralfoide at gmail
+ *
+ * This file is part of OpenSudoku.
+ *
+ * OpenSudoku is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenSudoku is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenSudoku.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cz.romario.opensudoku.game;
+
+import java.util.Set;
+
+import android.util.SparseIntArray;
+
+public class AutoPlaySolver {
+
+    private Cell mCell;
+    private int mValue;
+
+    AutoPlaySolver() {
+    }
+
+    public Cell getSolvedCell() {
+        return mCell;
+    }
+
+    public int getSolvedValue() {
+        return mValue;
+    }
+
+    public boolean solveNext(CellCollection cells) {
+
+        Cell candidateCell = null;
+        int newValue = 0;
+
+        // First we make sure there is not a single cell with no notes
+        // in it. This command must run after FillInNotesCommand, which sets
+        // notes for all empty cells. If such a cell fails to have a note
+        // that means there's conflict somewhere in the grid so we better
+        // abort here.
+        for (int r = 0; r < CellCollection.SUDOKU_SIZE; r++) {
+            for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
+                Cell cell = cells.getCell(r, c);
+
+                // Ignore cells with values
+                if (cell.getValue() > 0) continue;
+
+                CellNote note = cell.getNote();
+
+                Set<Integer> numbers = note.getNotedNumbers();
+                if (numbers.isEmpty()) {
+                    // Argh. Abort!
+                    return false;
+                }
+            }
+        }
+
+        // Now look for the easy case of a note that has only 1 value
+        simple_loop:
+        for (int r = 0; r < CellCollection.SUDOKU_SIZE; r++) {
+            for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
+                Cell cell = cells.getCell(r, c);
+
+                // Ignore cells with values
+                if (cell.getValue() > 0) continue;
+
+                CellNote note = cell.getNote();
+
+                Set<Integer> numbers = note.getNotedNumbers();
+                if (numbers.size() == 1) {
+                    candidateCell = cell;
+                    //noinspection UnnecessaryUnboxing
+                    newValue = numbers.iterator().next().intValue();
+                    break simple_loop;
+                }
+            }
+        }
+
+        if (candidateCell == null) {
+            // Second look at the more advanced case where all the
+            // notes have more than 1 number but in a given sector
+            // there is one value that is unique, in which case we
+            // select it.
+            sector_loop:
+            for (int s = 0; s < CellCollection.SUDOKU_SIZE; s++) {
+                CellGroup sector = cells.getSector(s);
+
+                SparseIntArray count = new SparseIntArray();
+                Cell[] found = new Cell[CellCollection.SUDOKU_SIZE + 1];
+
+                for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
+                    Cell cell = sector.getCell(c);
+
+                    // Ignore cells with values
+                    if (cell.getValue() > 0) continue;
+
+                    CellNote note = cell.getNote();
+
+                    for (Integer ii : note.getNotedNumbers()) {
+                        //noinspection UnnecessaryUnboxing
+                        int i = ii.intValue();
+                        if (i >= 1 && i <= CellCollection.SUDOKU_SIZE) {
+                            count.put(i, count.get(i) + 1);
+                            found[i] = cell;
+                        }
+                    }
+                }
+
+                // Find the first value with is present only once
+                int key = count.indexOfValue(1);
+                if (key > 0) {
+                    int c = count.keyAt(key);
+                    if (c >= 1 && c <= CellCollection.SUDOKU_SIZE) {
+                        candidateCell = found[c];
+                        newValue = c;
+                        break sector_loop;
+                    }
+                }
+            }
+        }
+
+        if (candidateCell != null) {
+            mCell = candidateCell;
+            mValue = newValue;
+        }
+        return mCell != null;
+    }
+}

--- a/OpenSudoku/src/cz/romario/opensudoku/game/Cell.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/Cell.java
@@ -222,6 +222,14 @@ public class Cell {
 		return mValid;
 	}
 
+	public void select() {
+		synchronized (mCellCollectionLock) {
+			if (mCellCollection != null) {
+				mCellCollection.setSelectedCell(this);
+			}
+		}
+	}
+	
 
 	/**
 	 * Creates instance from given <code>StringTokenizer</code>.

--- a/OpenSudoku/src/cz/romario/opensudoku/game/CellCollection.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/CellCollection.java
@@ -1,21 +1,21 @@
-/* 
+/*
  * Copyright (C) 2009 Roman Masek
- * 
+ *
  * This file is part of OpenSudoku.
- * 
+ *
  * OpenSudoku is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * OpenSudoku is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with OpenSudoku.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 
 package cz.romario.opensudoku.game;
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
  *
  * @author romario
  */
+@SuppressWarnings("MalformedRegex")
 public class CellCollection {
 
 	public static final int SUDOKU_SIZE = 9;
@@ -56,6 +57,8 @@ public class CellCollection {
 	private CellGroup[] mSectors;
 	private CellGroup[] mRows;
 	private CellGroup[] mColumns;
+
+    private Cell mSelectedCell;
 
 	private boolean mOnChangeEnabled = true;
 
@@ -134,14 +137,35 @@ public class CellCollection {
 
 	/**
 	 * Gets cell at given position.
-	 *
-	 * @param rowIndex
-	 * @param colIndex
+     * @param rowIndex 0..SUDOKU_SIZE-1
+     * @param colIndex 0..SUDOKU_SIZE-1
 	 * @return
 	 */
 	public Cell getCell(int rowIndex, int colIndex) {
 		return mCells[rowIndex][colIndex];
 	}
+
+    /**
+     * Returns a sector.
+     * @param index 0..SUDOKU_SIZE-1
+     * @return A group of SUDOKU_SIZE cells
+     */
+    public CellGroup getSector(int index) {
+        return mSectors[index];
+    }
+
+    public Cell getSelectedCell() {
+        return mSelectedCell;
+    }
+
+    public void setSelectedCell(Cell cell) {
+        mSelectedCell = cell;
+        onChange();
+    }
+
+    public void selectCell(int rowIndex, int colIndex) {
+        setSelectedCell(getCell(rowIndex, colIndex));
+    }
 
 	public void markAllCellsAsValid() {
 		mOnChangeEnabled = false;
@@ -310,7 +334,7 @@ public class CellCollection {
 	 * created by {@link #serialize(StringBuilder)} or {@link #serialize()} method).
 	 * earlier.
 	 *
-	 * @param note
+	 * @param data
 	 */
 	public static CellCollection deserialize(String data) {
 		// TODO: use DATA_PATTERN_VERSION_1 to validate and extract puzzle data
@@ -441,11 +465,11 @@ public class CellCollection {
 //	public boolean isOnChangeEnabled() {
 //		return mOnChangeEnabled;
 //	}
-//	
+//
 //	/**
 //	 * Enables or disables change notifications, that are distributed to the listeners
 //	 * registered by {@link #addOnChangeListener(OnChangeListener)}.
-//	 * 
+//	 *
 //	 * @param onChangeEnabled
 //	 */
 //	public void setOnChangeEnabled(boolean onChangeEnabled) {

--- a/OpenSudoku/src/cz/romario/opensudoku/game/CellGroup.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/CellGroup.java
@@ -35,6 +35,17 @@ public class CellGroup {
 	private Cell[] mCells = new Cell[CellCollection.SUDOKU_SIZE];
 	private int mPos = 0;
 
+    /**
+     * Returns the cell at the given index in the group.
+     * Ordering depends on the semantic of the group (row, column, sector).
+     *
+     * @param index 0..SUDOKU_SIZE-1
+     * @return A given Cell
+     */
+    public Cell getCell(int index) {
+        return mCells[index];
+    }
+
 	public void addCell(Cell cell) {
 		mCells[mPos] = cell;
 		mPos++;

--- a/OpenSudoku/src/cz/romario/opensudoku/game/SudokuGame.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/SudokuGame.java
@@ -40,6 +40,7 @@ public class SudokuGame {
 	private int mState;
 	private long mTime;
 	private long mLastPlayed;
+	private boolean mAutoFillInNotes;
 	private String mNote;
 	private CellCollection mCells;
 
@@ -96,6 +97,10 @@ public class SudokuGame {
 		mOnPuzzleSolvedListener = l;
 	}
 
+	public void setAutoFillInNotes(boolean autoFillInNotes) {
+        mAutoFillInNotes = autoFillInNotes;
+    }
+	
 	public void setNote(String note) {
 		mNote = note;
 	}
@@ -191,6 +196,10 @@ public class SudokuGame {
 				if (mOnPuzzleSolvedListener != null) {
 					mOnPuzzleSolvedListener.onPuzzleSolved();
 				}
+			}
+			
+			if (mAutoFillInNotes) {
+			    fillInNotes();
 			}
 		}
 	}

--- a/OpenSudoku/src/cz/romario/opensudoku/game/command/CommandStack.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/game/command/CommandStack.java
@@ -55,11 +55,13 @@ public class CommandStack {
 		}
 	}
 
-	public void setCheckpoint() {
+	public boolean setCheckpoint() {
 		if (!mCommandStack.empty()) {
 			AbstractCommand c = mCommandStack.peek();
 			c.setCheckpoint(true);
+            return true;
 		}
+        return false;
 	}
 
 	public boolean hasCheckpoint() {
@@ -72,7 +74,7 @@ public class CommandStack {
 
 	public void undoToCheckpoint() {
 		/*
-		 * I originally planned to just call undo but this way it doesn't need to 
+		 * I originally planned to just call undo but this way it doesn't need to
 		 * validateCells() until the run is complete
 		 */
 		AbstractCommand c;

--- a/OpenSudoku/src/cz/romario/opensudoku/gui/GameSettingsActivity.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/gui/GameSettingsActivity.java
@@ -45,8 +45,7 @@ public class GameSettingsActivity extends PreferenceActivity {
 			HintsQueue hm = new HintsQueue(GameSettingsActivity.this);
 			if (newVal) {
 				hm.resetOneTimeHints();
-			}
-			;
+			};
 			return true;
 		}
 

--- a/OpenSudoku/src/cz/romario/opensudoku/gui/SudokuPlayActivity.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/gui/SudokuPlayActivity.java
@@ -177,10 +177,15 @@ public class SudokuPlayActivity extends Activity {
 		mRootLayout.setPadding(screenPadding, screenPadding, screenPadding, screenPadding);
 
 		mFillInNotesEnabled = gameSettings.getBoolean("fill_in_notes_enabled", false);
-        boolean autoFillInNotes = mFillInNotesEnabled &&
-                           gameSettings.getBoolean("fill_in_notes_auto", false);
+        
+		boolean autoFillInNotes =
+		    mFillInNotesEnabled && gameSettings.getBoolean("fill_in_notes_auto", false);
         mSudokuGame.setAutoFillInNotes(autoFillInNotes);
 
+        boolean autoPlay =
+            autoFillInNotes && gameSettings.getBoolean("auto_play", false);
+        mSudokuGame.setAutoPlay(autoPlay);
+		
 		mSudokuBoard.setHighlightWrongVals(gameSettings.getBoolean("highlight_wrong_values", true));
 		mSudokuBoard.setHighlightTouchedCell(gameSettings.getBoolean("highlight_touched_cell", true));
 

--- a/OpenSudoku/src/cz/romario/opensudoku/gui/SudokuPlayActivity.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/gui/SudokuPlayActivity.java
@@ -177,6 +177,9 @@ public class SudokuPlayActivity extends Activity {
 		mRootLayout.setPadding(screenPadding, screenPadding, screenPadding, screenPadding);
 
 		mFillInNotesEnabled = gameSettings.getBoolean("fill_in_notes_enabled", false);
+        boolean autoFillInNotes = mFillInNotesEnabled &&
+                           gameSettings.getBoolean("fill_in_notes_auto", false);
+        mSudokuGame.setAutoFillInNotes(autoFillInNotes);
 
 		mSudokuBoard.setHighlightWrongVals(gameSettings.getBoolean("highlight_wrong_values", true));
 		mSudokuBoard.setHighlightTouchedCell(gameSettings.getBoolean("highlight_touched_cell", true));

--- a/OpenSudoku/src/cz/romario/opensudoku/gui/SudokuPlayActivity.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/gui/SudokuPlayActivity.java
@@ -1,21 +1,21 @@
-/* 
+/*
  * Copyright (C) 2009 Roman Masek
- * 
+ *
  * This file is part of OpenSudoku.
- * 
+ *
  * OpenSudoku is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * OpenSudoku is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with OpenSudoku.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 
 package cz.romario.opensudoku.gui;
@@ -38,6 +38,7 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.TextView;
+import android.widget.Toast;
 import cz.romario.opensudoku.R;
 import cz.romario.opensudoku.db.SudokuDatabase;
 import cz.romario.opensudoku.game.SudokuGame;
@@ -177,7 +178,7 @@ public class SudokuPlayActivity extends Activity {
 		mRootLayout.setPadding(screenPadding, screenPadding, screenPadding, screenPadding);
 
 		mFillInNotesEnabled = gameSettings.getBoolean("fill_in_notes_enabled", false);
-        
+
 		boolean autoFillInNotes =
 		    mFillInNotesEnabled && gameSettings.getBoolean("fill_in_notes_auto", false);
         mSudokuGame.setAutoFillInNotes(autoFillInNotes);
@@ -185,7 +186,7 @@ public class SudokuPlayActivity extends Activity {
         boolean autoPlay =
             autoFillInNotes && gameSettings.getBoolean("auto_play", false);
         mSudokuGame.setAutoPlay(autoPlay);
-		
+
 		mSudokuBoard.setHighlightWrongVals(gameSettings.getBoolean("highlight_wrong_values", true));
 		mSudokuBoard.setHighlightTouchedCell(gameSettings.getBoolean("highlight_touched_cell", true));
 
@@ -221,7 +222,7 @@ public class SudokuPlayActivity extends Activity {
 		super.onWindowFocusChanged(hasFocus);
 
 		if (hasFocus) {
-			// FIXME: When activity is resumed, title isn't sometimes hidden properly (there is black 
+			// FIXME: When activity is resumed, title isn't sometimes hidden properly (there is black
 			// empty space at the top of the screen). This is desperate workaround.
 			if (mFullScreen) {
 				mGuiHandler.postDelayed(new Runnable() {
@@ -454,6 +455,16 @@ public class SudokuPlayActivity extends Activity {
 			mSudokuBoard.setReadOnly(true);
 			showDialog(DIALOG_WELL_DONE);
 		}
+
+        @Override
+        public void onSetCheckpoint() {
+            Toast.makeText(SudokuPlayActivity.this, "Checkpoint set", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
+        public void onRestoreCheckpoint() {
+            Toast.makeText(SudokuPlayActivity.this, "Checkpoint restored", Toast.LENGTH_SHORT).show();
+        }
 
 	};
 

--- a/OpenSudoku/src/cz/romario/opensudoku/utils/AndroidUtils.java
+++ b/OpenSudoku/src/cz/romario/opensudoku/utils/AndroidUtils.java
@@ -42,6 +42,8 @@ public class AndroidUtils {
 			context.setTheme(R.style.Theme_PaperI);
 		} else if (theme.equals("paperii")) {
 			context.setTheme(R.style.Theme_PaperII);
+		} else if (theme.equals("night")) {
+		    context.setTheme(R.style.Theme_Night);
 		} else {
 			context.setTheme(R.style.Theme_Default);
 		}


### PR DESCRIPTION
This adds 3 features to OpenSudoku:

1- a simple green-on-black "night" theme.
2- a setting to automatically update fill-notes after a change.
3- an option to auto-solve trivial moves ... this works with the fill-notes features by solving unambiguous single notes. A demo of it can be found at http://www.youtube.com/watch?v=v1yzLl6TK6Y -- Obviously the solver is just a little fun thing, not serious. It's a setting that I don't think people would activate all the time, if at all.

I wrote these changes back in 2010 and ported them to OpenSudoku 1.1.5
